### PR TITLE
add codereviewmaster bot

### DIFF
--- a/bots/code_review_master.rb
+++ b/bots/code_review_master.rb
@@ -1,0 +1,202 @@
+require 'slackbot_frd'
+
+require_relative '../lib/code_review_master/data'
+require_relative '../lib/code_review_master/message'
+
+class CodeReviewMasterBot < SlackbotFrd::Bot
+  CODEREVIEWMASTER = 'codereviewmaster'
+
+  ADD_COMMAND = 'add'
+  CLEAR_COMMAND = 'clear'
+  HELP_COMMAND = 'help'
+  REMOVE_COMMAND = 'remove'
+  LIST_COMMAND = 'list'
+
+  def add_callbacks(slack_connection)
+    slack_connection.on_message do |user:, channel:, message:, timestamp:, thread_ts:|
+      if codereviewmaster?(user, message, channel, timestamp, thread_ts)
+        data = CodeReviewMaster::Data.new(channel, user)
+        m = CodeReviewMaster::Message.new(
+          slack_connection: slack_connection,
+          channel: channel,
+          thread_ts: thread_ts
+        )
+
+        ################
+        # Add reviewer #
+        ################
+        if (message_segment = add_reviewer_request?(message))
+          SlackbotFrd::Log.debug(
+            "user '#{user}' in channel '#{channel}' is adding reviewer with string #{message_segment}"
+          )
+          if (added_user = data.add_reviewer!(message_segment))
+            m.send_message("Added #{added_user} to the list of reviewers :shipit:")
+          else
+            m.send_message("Can't add a user with string #{message_segment} :fail:")
+          end
+        end
+
+        ###################
+        # Remove reviewer #
+        ###################
+        if (to_remove = remove_reviewer_request?(message))
+          SlackbotFrd::Log.debug(
+            "user '#{user}' in channel '#{channel}' is adding the reviewer #{to_remove}"
+          )
+          if data.remove_reviewer!(to_remove)
+            m.send_message("Removed #{to_remove} from the list of reviewers :shipit:")
+          else
+            m.send_message("Can't remove #{to_remove} from the list of reviewers :fail:")
+          end
+        end
+
+        ##################
+        # List reviewers #
+        ##################
+        if list_reviewers_request?(message)
+          SlackbotFrd::Log.debug(
+            "user '#{user}' in channel '#{channel}' is listing reviewers"
+          )
+          if data.reviewers.any?
+            m.send_message("Reviewers are: #{data.users.join(', ')}")
+          else
+            m.send_message("No reviewers yet! Add one like `codereviewmaster add <name>`")
+          end
+        end
+
+        ###################
+        # Clear reviewers #
+        ###################
+        if clear_reviewers_request?(message)
+          SlackbotFrd::Log.debug(
+            "user '#{user}' in channel '#{channel}' is clearing all reviewers"
+          )
+          if data.reviewers.any? && data.clear_reviewers!
+            m.send_message("Reviewers have been cleared!")
+          else
+            m.send_message("No reviewers yet! Add one like `codereviewmaster add <name>`")
+          end
+        end
+
+        ####################
+        # Output help text #
+        ####################
+        if help_output_request?(message)
+          SlackbotFrd::Log.debug(
+            "user '#{user}' in channel '#{channel}' is requesting help output"
+          )
+          help = <<-HELP_TEXT
+Hi! I help assign code reviewers.
+
+*Assign a reviewer*
+
+`codereviewmaster g/123456`
+
+Assigns a code reviewer to the provided gerrit change id. Posts in slack &
+assigns a reviewer in gerrit (assuming gerrit is configured).
+
+*List reviewers*
+
+`codereviewmaster list`
+
+Shows list of existing reviewers.
+
+*Add a reviewer*
+
+`codereviewmaster add john`
+
+or
+
+`codereviewmaster add slack:john gerrit:jcorrigan`
+
+Adds a new reviewer. Dups are ignored. If you just provide a string
+it assumes the same name for both slack & gerrit. If they are different,
+use the second syntax.
+
+*Remove a reviewer*
+
+`codereviewmaster remove jcorrigan`
+
+Works with either username.
+
+*Clear all reviewers*
+
+`codereviewmaster clear`
+
+Removes all reviewers
+
+*Help output*
+
+`codereviewmaster help`
+
+Outputs this text
+          HELP_TEXT
+          m.send_message(help)
+        end
+
+        #####################
+        # Assign a reviewer #
+        #####################
+        if (change_id = assign_review_request?(message))
+          SlackbotFrd::Log.debug(
+            "user '#{user}' in channel '#{channel}' is requesting a code review " \
+            "for change_id: #{change_id}"
+          )
+          if data.reviewers.any?
+            assigned = data.assign_reviewer!(change_id)
+            SlackbotFrd::Log.debug(
+              "user '#{assigned}' chosen to review '#{change_id}'"
+            )
+            m.send_message("Hey #{assigned} :wave-1:, can you review this :point_up:")
+
+            unless data.persist_to_gerrit!(
+              change_id: change_id,
+              assigned: assigned
+            )
+              m.send_message("Hm, I was unable to add #{assigned} as a reviewer in gerrit.")
+            end
+          else
+            m.send_message("No reviewers yet! Add one like `codereviewmaster add <name>`")
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+  ######################
+  # Determine requests #
+  ######################
+  def add_reviewer_request?(message)
+    (message.downcase.match(/^#{CODEREVIEWMASTER} #{ADD_COMMAND} (.+)/) || [])[1]
+  end
+
+  def assign_review_request?(message)
+    (message.downcase.match(/^#{CODEREVIEWMASTER} g\/(\d+)/i) || [])[1]
+  end
+
+  def clear_reviewers_request?(message)
+    message.downcase.match(/^#{CODEREVIEWMASTER} #{CLEAR_COMMAND}$/)
+  end
+
+  def codereviewmaster_request?(message)
+    message.downcase.match(/^#{CODEREVIEWMASTER}/)
+  end
+
+  def help_output_request?(message)
+    message.downcase.match(/^#{CODEREVIEWMASTER} #{HELP_COMMAND}$/)
+  end
+
+  def list_reviewers_request?(message)
+    message.downcase.match(/^#{CODEREVIEWMASTER} #{LIST_COMMAND}$/)
+  end
+
+  def remove_reviewer_request?(message)
+    (message.downcase.match(/^#{CODEREVIEWMASTER} #{REMOVE_COMMAND} (.+)/) || [])[1]
+  end
+
+  def codereviewmaster?(user, message, channel, timestamp, thread_ts)
+    message && codereviewmaster_request?(message) && user != :bot && timestamp != thread_ts
+  end
+end

--- a/bots/code_review_master.rb
+++ b/bots/code_review_master.rb
@@ -41,7 +41,7 @@ class CodeReviewMasterBot < SlackbotFrd::Bot
         ###################
         if (to_remove = remove_reviewer_request?(message))
           SlackbotFrd::Log.debug(
-            "user '#{user}' in channel '#{channel}' is adding the reviewer #{to_remove}"
+            "user '#{user}' in channel '#{channel}' is removing the reviewer #{to_remove}"
           )
           if data.remove_reviewer!(to_remove)
             m.send_message("Removed #{to_remove} from the list of reviewers :shipit:")
@@ -92,8 +92,10 @@ Hi! I help assign code reviewers.
 
 `codereviewmaster g/123456`
 
-Assigns a code reviewer to the provided gerrit change id. Posts in slack &
-assigns a reviewer in gerrit (assuming gerrit is configured).
+Assigns a code reviewer to the provided gerrit change id. It pulls possible
+reviewers from a list it maintains intnerally (see below for reviewer list
+managements.) Posts in slack & assigns a reviewer in gerrit (assuming gerrit
+is configured).
 
 *List reviewers*
 

--- a/bots/code_review_master.rb
+++ b/bots/code_review_master.rb
@@ -169,31 +169,31 @@ Outputs this text
   # Determine requests #
   ######################
   def add_reviewer_request?(message)
-    (message.downcase.match(/^#{CODEREVIEWMASTER} #{ADD_COMMAND} (.+)/) || [])[1]
+    (message.match(/^#{CODEREVIEWMASTER} #{ADD_COMMAND} (.+)/i) || [])[1]
   end
 
   def assign_review_request?(message)
-    (message.downcase.match(/^#{CODEREVIEWMASTER} g\/(\d+)/i) || [])[1]
+    (message.match(/^#{CODEREVIEWMASTER} g\/(\d+)/i) || [])[1]
   end
 
   def clear_reviewers_request?(message)
-    message.downcase.match(/^#{CODEREVIEWMASTER} #{CLEAR_COMMAND}$/)
+    message.match(/^#{CODEREVIEWMASTER} #{CLEAR_COMMAND}$/i)
   end
 
   def codereviewmaster_request?(message)
-    message.downcase.match(/^#{CODEREVIEWMASTER}/)
+    message.match(/^#{CODEREVIEWMASTER}/i)
   end
 
   def help_output_request?(message)
-    message.downcase.match(/^#{CODEREVIEWMASTER} #{HELP_COMMAND}$/)
+    message.match(/^#{CODEREVIEWMASTER} #{HELP_COMMAND}$/i)
   end
 
   def list_reviewers_request?(message)
-    message.downcase.match(/^#{CODEREVIEWMASTER} #{LIST_COMMAND}$/)
+    message.match(/^#{CODEREVIEWMASTER} #{LIST_COMMAND}$/i)
   end
 
   def remove_reviewer_request?(message)
-    (message.downcase.match(/^#{CODEREVIEWMASTER} #{REMOVE_COMMAND} (.+)/) || [])[1]
+    (message.match(/^#{CODEREVIEWMASTER} #{REMOVE_COMMAND} (.+)/i) || [])[1]
   end
 
   def codereviewmaster?(user, message, channel, timestamp, thread_ts)

--- a/lib/code_review_master/data.rb
+++ b/lib/code_review_master/data.rb
@@ -1,0 +1,144 @@
+require_relative '../dynamo'
+require_relative '../gerrit/change'
+
+require_relative './message_segment'
+require_relative './user'
+
+module CodeReviewMaster
+  class Data
+    def initialize(channel, slack_username)
+      @channel = channel
+      @slack_username = slack_username
+    end
+
+    def add_reviewer!(segment)
+      begin
+        user = CodeReviewMaster::MessageSegment.new(segment).to_user
+        return user if reviewers.map(&:values).flatten.any? { |name| user.to_h.values.include?(name) }
+        return user if (config['reviewers'] << user.to_h && save!)
+      rescue CodeReviewMaster::MessageSegment::ParseError => e
+        SlackbotFrd::Log.debug(
+          "Failed to parse user segnment: #{segment}"
+        )
+        false
+      end
+    end
+
+    def assign_reviewer!(change_id)
+      dup_reviewers = reviewers.dup
+      slack_user_index = dup_reviewers.index do |reviewer|
+        reviewer['slack'] == slack_username
+      end
+      if slack_user_index != 0
+        assigned = dup_reviewers.shift
+      else
+        assigned = dup_reviewers.slice!(1)
+      end
+
+      dup_reviewers << assigned
+      self.reviewers = dup_reviewers
+      save!
+      CodeReviewMaster::User.new(assigned)
+    end
+
+    def clear_reviewers!
+      self.reviewers = []
+      save!
+    end
+
+    def persist_to_gerrit!(change_id:, assigned:)
+      if change_api
+        begin
+          change_api.add_reviewer(
+            id: change_id,
+            account_id: assigned.gerrit_username
+          )
+        rescue StandardError => e
+          SlackbotFrd::Log.warn(
+            "Error encountered sending reviewer to gerrit #{change_id}'.  " \
+            "Message: #{e.message}.\n#{e}"
+          )
+          false
+        end
+      else
+        SlackbotFrd::Log.warn(
+          "Gerrit is not configured."
+        )
+        false
+      end
+    end
+
+    def remove_reviewer!(name)
+      SlackbotFrd::Log.warn(
+        "Remove reviewer name: #{name} " \
+        "#{reviewers.map(&:values).flatten}"
+      )
+      return true unless reviewers.map(&:values).flatten.include?(name)
+      return true if config['reviewers'].delete_if do |reviewer|
+        reviewer.values.include?(name)
+      end && save!
+      false
+    end
+
+    def reviewers
+      config['reviewers']
+    end
+
+    def users
+      reviewers.map {|reviewer| CodeReviewMaster::User.new(reviewer) }
+    end
+
+    private
+    attr_reader :channel, :slack_username
+
+    def change_api
+      return nil unless gerrit_configured?
+
+      @_change_api ||= Gerrit::Change.new(
+        username: $slackbotfrd_conf['gerrit_username'],
+        password: $slackbotfrd_conf['gerrit_password']
+      )
+    end
+
+    def config
+      unless @_config
+        item = db.get_item(
+          table: table_name,
+          primary: channel
+        ).item
+        @_config = (item || {
+          'reviewers' => []
+        })
+      end
+      @_config
+    end
+
+    def db
+      unless @_db
+        @_db = DynamoDB.new(botname: 'angelbot')
+        @_db.create_table(table_name, if_not_exist: true)
+      end
+      @_db
+    end
+
+    def gerrit_configured?
+      $slackbotfrd_conf['gerrit_username'] && $slackbotfrd_conf['gerrit_password']
+    end
+
+    def reviewers=(new_reviewers)
+      config['reviewers'] = new_reviewers
+    end
+
+    def save!
+      db.put_item(
+        table: table_name,
+        primary: channel,
+        attrs: config
+      )
+    end
+
+    def table_name
+      "code_review_master_channel_settings"
+    end
+  end
+end

--- a/lib/code_review_master/data.rb
+++ b/lib/code_review_master/data.rb
@@ -116,7 +116,9 @@ module CodeReviewMaster
     def db
       unless @_db
         @_db = DynamoDB.new(botname: 'angelbot')
-        @_db.create_table(table_name, if_not_exist: true)
+        # For local development feel free to uncomment this to
+        # create the table. Production permissions do not allow.
+        # @_db.create_table(table_name, if_not_exist: true)
       end
       @_db
     end

--- a/lib/code_review_master/data.rb
+++ b/lib/code_review_master/data.rb
@@ -115,7 +115,7 @@ module CodeReviewMaster
 
     def db
       unless @_db
-        @_db = DynamoDB.new(botname: 'angelbot')
+        @_db = DynamoDB.new(botname: 'codereviewmaster')
         # For local development feel free to uncomment this to
         # create the table. Production permissions do not allow.
         # @_db.create_table(table_name, if_not_exist: true)

--- a/lib/code_review_master/message.rb
+++ b/lib/code_review_master/message.rb
@@ -1,0 +1,20 @@
+module CodeReviewMaster
+  class Message
+    def initialize(slack_connection:, channel:, thread_ts:)
+      @slack_connection = slack_connection
+      @channel = channel
+      @thread_ts = thread_ts
+    end
+
+    def send_message(message)
+      slack_connection.send_message(
+        channel: channel,
+        message: message,
+        thread_ts: thread_ts
+      )
+    end
+
+    private
+    attr_reader :slack_connection, :channel, :thread_ts
+  end
+end

--- a/lib/code_review_master/message_segment.rb
+++ b/lib/code_review_master/message_segment.rb
@@ -1,0 +1,61 @@
+module CodeReviewMaster
+  # Translates a string into a hash understood by the
+  # User object
+  #
+  # Either a single string name like:
+  #
+  # `jcorrigan`
+  #
+  # or one or more key value pairs
+  #
+  # `slack:john gerrit:jcorrigan`
+  #
+  # If you only provide one (for some reason) it
+  # sets it for all keys, in this case, slack & gerrit.
+  class MessageSegment
+    class ParseError < StandardError; end
+
+    KEYS = [
+      'slack', 'gerrit'
+    ]
+
+    def initialize(message_segment)
+      @message_segment = message_segment
+    end
+
+    def to_user
+      a = message_segment.split(' ')
+
+      if a.length == 1
+        User.new({
+          'slack' => a.first,
+          'gerrit' => a.first
+        })
+      else
+        h = pad_empty_keys(assign_usernames(a))
+        User.new(h)
+      end
+    end
+
+    private
+    attr_reader :message_segment
+
+    def assign_usernames(segments)
+      segments.each_with_object({}) do |s, memo|
+        k, v = s.split(':')
+        raise ParseError unless k && v
+
+        if KEYS.include?(k)
+          memo[k] = v
+        end
+      end
+    end
+
+    def pad_empty_keys(h)
+      KEYS.each do |k|
+        h[k] = a[0].split(':')[1] unless h.keys.include?(k)
+      end
+      h
+    end
+  end
+end

--- a/lib/code_review_master/user.rb
+++ b/lib/code_review_master/user.rb
@@ -1,0 +1,26 @@
+module CodeReviewMaster
+  class User
+    def initialize(attrs)
+      @attrs = attrs
+    end
+
+    def gerrit_username
+      attrs['gerrit']
+    end
+
+    def slack_username
+      attrs['slack']
+    end
+
+    def to_h
+      attrs
+    end
+
+    def to_s
+      slack_username
+    end
+
+    private
+    attr_reader :attrs
+  end
+end

--- a/lib/gerrit/change.rb
+++ b/lib/gerrit/change.rb
@@ -15,9 +15,28 @@ module Gerrit
 
     def get(id)
       ret = self.class.get("/#{id}/detail", basic_auth: basic_auth).body.split("\n")
-      # gerrit puts some weird cruft in the way at the top
-      ret.shift
-      JSON.parse(ret.join("\n"))
+      parse_response(ret)
+    end
+
+    # Calling this param `account_id` to mirror the gerrit api docs.
+    # From the docs an account id can be:
+    # - a string of the format "Full Name <email@example.com>"
+    # - just the email address ("email@example")
+    # - a full name if it is unique ("Full Name")
+    # - an account ID ("18419")
+    # - a user name ("username")
+    # - self for the calling user
+    def add_reviewer(id:, account_id:)
+      ret = self.class.post("/#{id}/reviewers",
+        basic_auth: basic_auth,
+        body: {
+          reviewer: account_id
+        }.to_json,
+        headers: {
+          'Content-Type' => 'application/json;charset=UTF-8'
+        }
+      ).body.split("\n")
+      parse_response(ret)
     end
 
     private
@@ -27,6 +46,12 @@ module Gerrit
         username: @username,
         password: @password
       }
+    end
+
+    def parse_response(ret)
+      # gerrit puts some weird cruft in the way at the top
+      ret.shift
+      JSON.parse(ret.join("\n"))
     end
   end
 end


### PR DESCRIPTION
Listens for the string `codereviewmaster`.

Understands the following commands:

`codereviewmaster add jcorrigan` || `codereviewmaster add slack:john
gerrit:jcorrigan`

Adds a user to a list of available reviewers.

`codereviewmaster remove jcorrigan`

Removes user from list of available reviewers

`codereviewmaster list`

Shows list of available reviewers

`codereviewmaster g/123456`

Selects a reviewer for the provided gerrit change; adds the reviewer in
gerrit (if gerrit creds are present).